### PR TITLE
feat(events)!: adding a verified column

### DIFF
--- a/lib/event_relay/events/event.ex
+++ b/lib/event_relay/events/event.ex
@@ -23,6 +23,7 @@ defmodule ER.Events.Event do
           occurred_at: DateTime.t(),
           offset: integer(),
           source: String.t(),
+          verified: String.t(),
           context: map(),
           errors: list(),
           durable: boolean(),
@@ -46,6 +47,7 @@ defmodule ER.Events.Event do
              :occurred_at,
              :offset,
              :source,
+             :verified,
              :context,
              :errors,
              :group_key,
@@ -67,6 +69,7 @@ defmodule ER.Events.Event do
     field :occurred_at, :utc_datetime
     field :offset, :integer, read_after_writes: true
     field :source, :string
+    field :verified, :boolean, default: false
 
     # This can be used to segment events. For instance, it can store a tenant, account, or organization id
     field :group_key, :string
@@ -111,7 +114,8 @@ defmodule ER.Events.Event do
       :anonymous_id,
       :subscription_locks,
       :data_schema,
-      :data_schema_json
+      :data_schema_json,
+      :verified
     ])
     |> decode_context()
     |> decode_data()

--- a/lib/event_relay_web/channels/events_channel.ex
+++ b/lib/event_relay_web/channels/events_channel.ex
@@ -42,6 +42,7 @@ defmodule ERWeb.EventsChannel do
         response = %{status: "ok"}
         {topic_name, topic_identifier} = ER.Events.Topic.parse_topic(topic)
         durable = unless ER.boolean?(durable), do: false, else: to_boolean(durable)
+        verified = true
 
         Enum.map(events, fn event ->
           case ER.Events.produce_event_for_topic(%{
@@ -53,6 +54,7 @@ defmodule ERWeb.EventsChannel do
                  user_id: Map.get(event, "user_id"),
                  anonymous_id: Map.get(event, "anonymous_id"),
                  durable: durable,
+                 verified: verified,
                  topic_name: topic_name,
                  topic_identifier: topic_identifier
                }) do

--- a/lib/event_relay_web/controllers/event_controller.ex
+++ b/lib/event_relay_web/controllers/event_controller.ex
@@ -10,6 +10,7 @@ defmodule ERWeb.EventController do
   def publish(conn, %{"topic" => topic, "durable" => durable, "events" => events}) do
     {topic_name, topic_identifier} = ER.Events.Topic.parse_topic(topic)
     durable = unless ER.boolean?(durable), do: false, else: to_boolean(durable)
+    verified = true
 
     unless ER.empty?(topic_name) do
       case Bosun.permit(conn.assigns.api_key, :publish_events, %Event{}, topic_name: topic_name) do
@@ -28,6 +29,7 @@ defmodule ERWeb.EventController do
                      user_id: indifferent_get(event, :user_id),
                      anonymous_id: indifferent_get(event, :anonymous_id),
                      durable: durable,
+                     verified: verified,
                      topic_name: topic_name,
                      topic_identifier: topic_identifier
                    }) do

--- a/lib/event_relay_web/grpc/events/server.ex
+++ b/lib/event_relay_web/grpc/events/server.ex
@@ -22,6 +22,7 @@ defmodule ERWeb.Grpc.EventRelay.Events.Server do
     events = request.events
     topic = request.topic
     {topic_name, topic_identifier} = ER.Events.Topic.parse_topic(topic)
+    verified = true
 
     if topic_name do
       events =
@@ -38,6 +39,7 @@ defmodule ERWeb.Grpc.EventRelay.Events.Server do
                  user_id: Map.get(event, :user_id),
                  anonymous_id: Map.get(event, :anonymous_id),
                  durable: request.durable,
+                 verified: verified,
                  topic_name: topic_name,
                  topic_identifier: topic_identifier,
                  data_schema_json: Map.get(event, :data_schema)

--- a/priv/repo/migrations/20231222182531_add_verified_to_events.exs
+++ b/priv/repo/migrations/20231222182531_add_verified_to_events.exs
@@ -1,0 +1,13 @@
+defmodule ER.Repo.Migrations.AddVerifiedToEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:events, primary_key: false) do
+      add :verified, :boolean, default: false
+    end
+
+    alter table(:dead_letter_events, primary_key: false) do
+      add :verified, :boolean, default: false
+    end
+  end
+end


### PR DESCRIPTION
This will be used with signature checking to set whether the event's signature has been verified. This could apply to an inbound webhook or an event that has an HMAC in the content.