### PR TITLE
ref!: add test for jwt and accept a single token for websockets

### DIFF
--- a/lib/event_relay/token.ex
+++ b/lib/event_relay/token.ex
@@ -38,12 +38,24 @@ defmodule ER.JWT.Token do
 
   def merge_api_key_claims(claims, %ApiKey{type: :consumer} = api_key) do
     destination_ids = Repo.preload(api_key, :destinations).destinations |> Enum.map(& &1.id)
-    Map.merge(claims, %{sub_ids: destination_ids}) |> merge_default_api_key_claims(api_key)
+
+    Map.merge(claims, %{destination_ids: destination_ids})
+    |> merge_default_api_key_claims(api_key)
   end
 
   def merge_api_key_claims(claims, %ApiKey{type: :producer} = api_key) do
     topic_names = Repo.preload(api_key, :topics).topics |> Enum.map(& &1.name)
     Map.merge(claims, %{topic_names: topic_names}) |> merge_default_api_key_claims(api_key)
+  end
+
+  def merge_api_key_claims(claims, %ApiKey{type: :producer_consumer} = api_key) do
+    destination_ids = Repo.preload(api_key, :destinations).destinations |> Enum.map(& &1.id)
+    topic_names = Repo.preload(api_key, :topics).topics |> Enum.map(& &1.name)
+
+    claims
+    |> Map.merge(%{destination_ids: destination_ids})
+    |> Map.merge(%{topic_names: topic_names})
+    |> merge_default_api_key_claims(api_key)
   end
 
   def merge_api_key_claims(claims, %ApiKey{type: :admin} = api_key) do

--- a/test/event_relay_web/channels/events_channel_test.exs
+++ b/test/event_relay_web/channels/events_channel_test.exs
@@ -7,15 +7,13 @@ defmodule ERWeb.EventsChannelTest do
   setup :verify_on_exit!
 
   setup do
-    producer_api_key = insert(:api_key, type: :producer)
-    consumer_api_key = insert(:api_key)
+    api_key = insert(:api_key, type: :producer_consumer)
     topic = insert(:topic)
     destination = insert(:destination, topic: topic)
-    insert(:api_key_destination, api_key: producer_api_key, destination: destination)
-    insert(:api_key_topic, api_key: producer_api_key, topic: topic)
+    insert(:api_key_destination, api_key: api_key, destination: destination)
+    insert(:api_key_topic, api_key: api_key, topic: topic)
 
-    {:ok, producer_token} = ER.JWT.Token.build(producer_api_key)
-    {:ok, consumer_token} = ER.JWT.Token.build(consumer_api_key)
+    {:ok, token} = ER.JWT.Token.build(api_key)
 
     expect(ER.Events.ChannelCacheBehaviorMock, :register_socket, fn _pid, _destination_id ->
       1
@@ -28,8 +26,7 @@ defmodule ERWeb.EventsChannelTest do
       ERWeb.UserSocket
       |> socket("user_id", %{some: :assign})
       |> subscribe_and_join(ERWeb.EventsChannel, "events:#{destination.id}", %{
-        "producer_token" => producer_token,
-        "consumer_token" => consumer_token
+        "token" => token
       })
 
     %{socket: socket, topic: topic, destination: destination}


### PR DESCRIPTION
Now that we have a producer_consumer type of API Key we don't need to accept 2 JWT tokens - one for a producer and one for a consumer.