### PR TITLE
feat(events)!: adding available_at to event

### DIFF
--- a/event_relay.proto
+++ b/event_relay.proto
@@ -157,6 +157,7 @@ message NewEvent {
   // JSON Schema for the event data
   string data_schema = 11; // stringified JSON
   string prev_id = 12;
+  string available_at = 13; // when the event is available
 }
 
 message Event {
@@ -177,6 +178,7 @@ message Event {
   // JSON Schema for the event data
   string data_schema = 15; // stringified JSON
   string prev_id = 16;
+  string available_at = 17; // when the event is available
 }
 
 message PublishEventsRequest {

--- a/lib/event_relay_web/grpc/event_relay.pb.ex
+++ b/lib/event_relay_web/grpc/event_relay.pb.ex
@@ -190,6 +190,7 @@ defmodule ERWeb.Grpc.Eventrelay.NewEvent do
   field :context, 10, repeated: true, type: ERWeb.Grpc.Eventrelay.NewEvent.ContextEntry, map: true
   field :data_schema, 11, type: :string, json_name: "dataSchema"
   field :prev_id, 12, type: :string, json_name: "prevId"
+  field :available_at, 13, type: :string, json_name: "availableAt"
 end
 
 defmodule ERWeb.Grpc.Eventrelay.Event.ContextEntry do
@@ -218,6 +219,7 @@ defmodule ERWeb.Grpc.Eventrelay.Event do
   field :errors, 14, repeated: true, type: :string
   field :data_schema, 15, type: :string, json_name: "dataSchema"
   field :prev_id, 16, type: :string, json_name: "prevId"
+  field :available_at, 17, type: :string, json_name: "availableAt"
 end
 
 defmodule ERWeb.Grpc.Eventrelay.PublishEventsRequest do

--- a/lib/event_relay_web/grpc/events/server.ex
+++ b/lib/event_relay_web/grpc/events/server.ex
@@ -36,6 +36,7 @@ defmodule ERWeb.Grpc.EventRelay.Events.Server do
                  data_json: Map.get(event, :data),
                  context: Map.get(event, :context),
                  occurred_at: Map.get(event, :occurred_at),
+                 available_at: Map.get(event, :available_at),
                  user_key: Map.get(event, :user_key),
                  anonymous_key: Map.get(event, :anonymous_key),
                  durable: request.durable,
@@ -171,6 +172,13 @@ defmodule ERWeb.Grpc.EventRelay.Events.Server do
         DateTime.to_iso8601(event.occurred_at)
       end
 
+    available_at =
+      if ER.empty?(event.available_at) do
+        ""
+      else
+        DateTime.to_iso8601(event.available_at)
+      end
+
     GrpcEvent.new(
       id: event.id,
       name: event.name,
@@ -182,6 +190,7 @@ defmodule ERWeb.Grpc.EventRelay.Events.Server do
       data: Event.data_json(event),
       context: event.context,
       occurred_at: occurred_at,
+      available_at: available_at,
       offset: event.offset,
       user_key: event.user_key,
       anonymous_key: event.anonymous_key,

--- a/priv/repo/migrations/20240103190022_add_available_at_to_events.exs
+++ b/priv/repo/migrations/20240103190022_add_available_at_to_events.exs
@@ -1,0 +1,13 @@
+defmodule ER.Repo.Migrations.AddAvailableAtToEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:events, primary_key: false) do
+      add :available_at, :utc_datetime
+    end
+
+    alter table(:dead_letter_events, primary_key: false) do
+      add :available_at, :utc_datetime
+    end
+  end
+end

--- a/test/event_relay_web/grpc/events/server_test.exs
+++ b/test/event_relay_web/grpc/events/server_test.exs
@@ -23,6 +23,7 @@ defmodule ERWeb.Grpc.EventRelay.Events.ServerTest do
     test "publishes events", %{topic: topic} do
       event_name = "entry.created"
       group_key = "groupkey"
+      available_at = DateTime.to_iso8601(~U[2021-12-21 18:27:00Z])
 
       request = %PublishEventsRequest{
         topic: topic.name,
@@ -32,7 +33,8 @@ defmodule ERWeb.Grpc.EventRelay.Events.ServerTest do
             name: event_name,
             data: Jason.encode!(%{}),
             source: "test",
-            group_key: group_key
+            group_key: group_key,
+            available_at: available_at
           }
         ]
       }
@@ -43,8 +45,14 @@ defmodule ERWeb.Grpc.EventRelay.Events.ServerTest do
 
       assert event.name == event_name
       assert event.group_key == group_key
+      assert event.available_at == available_at
 
       events = Events.list_events_for_topic(topic_name: topic.name)
+
+      db_event = List.first(events)
+
+      assert Flamel.Moment.to_iso8601(db_event.available_at) == available_at
+
       assert Enum.count(events) == 1
     end
 


### PR DESCRIPTION
When using the list_events_for_topic and list_queued_events_for_topic they will respect the available_at value and not return events where the available_at is not less then or equal to the current time. This facilitate the concept of delayed events. This could be used with webhoooks to schedule retries in the future or with a work queue to schedule jobs to happen after a given time.